### PR TITLE
Update for enhance(es7) config for miniprogram-ci

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ class Ci {
         this.projectConfig = {
           appid: config.appid,
           miniprogramRoot: config.miniprogramRoot,
-          setting: config.setting,
+          setting: config.setting ? {...config.setting, es7: !!config.setting.enhance} : {},
           compileType: config.compileType,
         };
 


### PR DESCRIPTION
As in `miniprogram-ci`, enhance mode has been marked as `es7`. 
I suppose very few people realized this and most of them shall use `enhance` in `project.config.json`.